### PR TITLE
adjust parsing

### DIFF
--- a/vbus/src/main/java/de/resol/vbus/TcpDataSourceProvider.java
+++ b/vbus/src/main/java/de/resol/vbus/TcpDataSourceProvider.java
@@ -233,7 +233,7 @@ public class TcpDataSourceProvider extends DataSourceProvider {
 		
 		String vendor = null, product = null, serial = null, version = null, build = null, name = null, features = null;
 
-		Pattern re = Pattern.compile("^([^ =]+)\\s*=\\s*\"(.*)\"$");
+		Pattern re = Pattern.compile("^([^ =\t]+)\\s*=\\s*\"(.*)\"$");
 
 		String line;
 		while ((line = in.readLine()) != null) {


### PR DESCRIPTION
my VBusLAN adapter with SW version 1.0.2 seems to output tabs, so we should not include them in the key, I guess.