### PR TITLE
add access to all know units

### DIFF
--- a/vbus/src/main/java/de/resol/vbus/Specification.java
+++ b/vbus/src/main/java/de/resol/vbus/Specification.java
@@ -551,6 +551,15 @@ public class Specification {
 		
 		return result;
 	}
+    
+	/**
+	  * Get the list of known units.
+	  *
+	  * @return array of known Units.
+	  */
+	  public Unit[] getUnits() {
+		return specificationFile.getUnits();
+	  }
 	
 	/**
 	 * Get optional raw value from `Packet` payload data as a Long.


### PR DESCRIPTION
I propose to export access to all units defined in the VSF.

Could also be interesting to export the list of known devices but as I do not need those right now I kept it for now.