### PR TITLE
Add `setConfiguration` methods

### DIFF
--- a/vbus/src/main/java/de/resol/vbus/BaseConfigurationOptimizer.java
+++ b/vbus/src/main/java/de/resol/vbus/BaseConfigurationOptimizer.java
@@ -112,6 +112,10 @@ public abstract class BaseConfigurationOptimizer implements ConfigurationOptimiz
 	public ConfigurationValue[] optimizeSaveConfiguration(ConfigurationValue[] newValues, ConfigurationValue[] oldValues) {
 		return newValues;
 	}
+
+	public ConfigurationValue[] optimizeSetConfiguration(ConfigurationValue[] newValues, ConfigurationValue[] oldValues) {
+		return newValues;
+	}
 	
 	public ConfigurationValue[] generateClockConfiguration(long time, TimeZone timeZone) {
 		return new ConfigurationValue [0];

--- a/vbus/src/main/java/de/resol/vbus/ConfigurationOptimizer.java
+++ b/vbus/src/main/java/de/resol/vbus/ConfigurationOptimizer.java
@@ -49,7 +49,7 @@ public interface ConfigurationOptimizer {
 
 	/**
 	 * Gets an optimized array of `ConfigurationValue` objects based on what
-	 * values were set in the device befor.
+	 * values were set in the device before.
 	 * 
 	 * @param newValues An array of new `ConfigurationValue` objects to set.
 	 * @param oldValues An array of already set `ConfigurationValue` object.

--- a/vbus/src/main/java/de/resol/vbus/ConfigurationOptimizer.java
+++ b/vbus/src/main/java/de/resol/vbus/ConfigurationOptimizer.java
@@ -56,6 +56,7 @@ public interface ConfigurationOptimizer {
 	 * @return An array of `ConfigurationValue` objects to set next.
 	 */
 	public abstract ConfigurationValue[] optimizeSaveConfiguration(ConfigurationValue[] newValues, ConfigurationValue[] oldValues);
+	public abstract ConfigurationValue[] optimizeSetConfiguration(ConfigurationValue[] newValues, ConfigurationValue[] oldValues);
 
 	/**
 	 * Gets an array of `ConfigurationValue` objects to set the device to

--- a/vbus/src/main/java/de/resol/vbus/ConfigurationOptimizerFactory.java
+++ b/vbus/src/main/java/de/resol/vbus/ConfigurationOptimizerFactory.java
@@ -24,7 +24,6 @@
 package de.resol.vbus;
 
 import de.resol.vbus.ConfigurationOptimizerMatcher.MatcherState;
-import de.resol.vbus.configurationoptimizers.RegumaqX45ConfigurationOptimizer;
 import de.resol.vbus.configurationoptimizers.ResolDeltaSolCsPlusXxxConfigurationOptimizer;
 
 public final class ConfigurationOptimizerFactory {
@@ -39,7 +38,6 @@ public final class ConfigurationOptimizerFactory {
 		if (matchers == null) {
 			matchers = new ConfigurationOptimizerMatcher[] {
 				ResolDeltaSolCsPlusXxxConfigurationOptimizer.getMatcher(),
-				RegumaqX45ConfigurationOptimizer.getMatcher(),
 				// NOTE(daniel): add more here...
 			};
 		}

--- a/vbus/src/main/java/de/resol/vbus/ConfigurationOptimizerFactory.java
+++ b/vbus/src/main/java/de/resol/vbus/ConfigurationOptimizerFactory.java
@@ -24,6 +24,7 @@
 package de.resol.vbus;
 
 import de.resol.vbus.ConfigurationOptimizerMatcher.MatcherState;
+import de.resol.vbus.configurationoptimizers.RegumaqX45ConfigurationOptimizer;
 import de.resol.vbus.configurationoptimizers.ResolDeltaSolCsPlusXxxConfigurationOptimizer;
 
 public final class ConfigurationOptimizerFactory {
@@ -38,6 +39,7 @@ public final class ConfigurationOptimizerFactory {
 		if (matchers == null) {
 			matchers = new ConfigurationOptimizerMatcher[] {
 				ResolDeltaSolCsPlusXxxConfigurationOptimizer.getMatcher(),
+				RegumaqX45ConfigurationOptimizer.getMatcher(),
 				// NOTE(daniel): add more here...
 			};
 		}

--- a/vbus/src/main/java/de/resol/vbus/ConnectionCustomizer.java
+++ b/vbus/src/main/java/de/resol/vbus/ConnectionCustomizer.java
@@ -139,9 +139,9 @@ public class ConnectionCustomizer extends Customizer {
 			public ConfigurationValue[] filterConfigurationValues(ConfigurationValue[] values, int round) {
 				if (optimize) {
 					if (round == 1) {
-						values = ConnectionCustomizer.this.getOptimizer().optimizeSaveConfiguration(newValues, oldValues);
+						values = ConnectionCustomizer.this.getOptimizer().optimizeSetConfiguration(newValues, oldValues);
 					} else {
-						values = ConnectionCustomizer.this.getOptimizer().optimizeSaveConfiguration(newValues, values);
+						values = ConnectionCustomizer.this.getOptimizer().optimizeSetConfiguration(newValues, values);
 					}
 				} else {
 					if (round == 1) {

--- a/vbus/src/main/java/de/resol/vbus/ConnectionCustomizer.java
+++ b/vbus/src/main/java/de/resol/vbus/ConnectionCustomizer.java
@@ -131,6 +131,33 @@ public class ConnectionCustomizer extends Customizer {
 
 		});
 	}
+
+	@Override
+	protected ConfigurationValue[] setConfigurationInternal(final ConfigurationValue[] newValues, final ConfigurationValue[] oldValues, final boolean optimize) throws IOException {
+		return transceiveConfiguration(TransceiveAction.SET, new ConfigurationValueFilter() {
+			
+			public ConfigurationValue[] filterConfigurationValues(ConfigurationValue[] values, int round) {
+				if (optimize) {
+					if (round == 1) {
+						values = ConnectionCustomizer.this.getOptimizer().optimizeSaveConfiguration(newValues, oldValues);
+					} else {
+						values = ConnectionCustomizer.this.getOptimizer().optimizeSaveConfiguration(newValues, values);
+					}
+				} else {
+					if (round == 1) {
+						values = newValues;
+
+						for (int i = 0; i < values.length; i++) {
+							values [i].setPending(true);
+						}
+					}
+				}
+
+				return values;
+			}
+
+		});
+	}
 	
 	public ConfigurationValue[] transceiveConfiguration(TransceiveAction action, ConfigurationValueFilter filter) throws IOException {
 		TransceiveState state = new TransceiveState();

--- a/vbus/src/main/java/de/resol/vbus/Customizer.java
+++ b/vbus/src/main/java/de/resol/vbus/Customizer.java
@@ -66,6 +66,19 @@ public abstract class Customizer {
 		return saveConfigurationInternal(newValues, oldValues, optimize);
 	}
 	
+	public ConfigurationValue[] setConfiguration(ConfigurationValue[] newValues, ConfigurationValue[] oldValues, boolean optimize) throws IOException {
+		if (optimizer != null) {
+			newValues = optimizer.completeConfiguration(newValues);
+		
+			if (oldValues != null) {
+				oldValues = optimizer.completeConfiguration(oldValues);
+			}
+		}
+		
+		return setConfigurationInternal(newValues, oldValues, optimize);
+	}
+	
+	protected abstract ConfigurationValue[] setConfigurationInternal(ConfigurationValue[] newValues, ConfigurationValue[] oldValues, boolean optimize) throws IOException;
 	protected abstract ConfigurationValue[] saveConfigurationInternal(ConfigurationValue[] newValues, ConfigurationValue[] oldValues, boolean optimize) throws IOException;
 
 }

--- a/vbus/src/main/java/de/resol/vbus/Customizer.java
+++ b/vbus/src/main/java/de/resol/vbus/Customizer.java
@@ -78,7 +78,7 @@ public abstract class Customizer {
 		return setConfigurationInternal(newValues, oldValues, optimize);
 	}
 	
-	protected abstract ConfigurationValue[] setConfigurationInternal(ConfigurationValue[] newValues, ConfigurationValue[] oldValues, boolean optimize) throws IOException;
 	protected abstract ConfigurationValue[] saveConfigurationInternal(ConfigurationValue[] newValues, ConfigurationValue[] oldValues, boolean optimize) throws IOException;
+	protected abstract ConfigurationValue[] setConfigurationInternal(ConfigurationValue[] newValues, ConfigurationValue[] oldValues, boolean optimize) throws IOException;
 
 }

--- a/vbus/src/main/java/de/resol/vbus/configurationoptimizers/RegumaqX45ConfigurationOptimizer.java
+++ b/vbus/src/main/java/de/resol/vbus/configurationoptimizers/RegumaqX45ConfigurationOptimizer.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (C) 2008-2016, RESOL - Elektronische Regelungen GmbH.
+ * Copyright (C) 2016, Daniel Wippermann.
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to permit
+ * persons to whom the Software is furnished to do so, subject to the
+ * following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+package de.resol.vbus.configurationoptimizers;
+
+import java.util.TimeZone;
+
+import de.resol.vbus.BaseConfigurationOptimizer;
+import de.resol.vbus.ConfigurationOptimizer;
+import de.resol.vbus.ConfigurationOptimizerMatcher;
+import de.resol.vbus.ConfigurationValue;
+import de.resol.vbus.Customizer;
+
+public class RegumaqX45ConfigurationOptimizer extends BaseConfigurationOptimizer {
+
+	@Override
+	public ConfigurationValue[] getAdjustableValues() {
+		return new ConfigurationValue[] {
+			createConfigurationValueDescriptor("WarmwasserTSoll", 0x0037, 0x5fc5f901, 0),
+			createConfigurationValueDescriptor("Relais1Handbetrieb", 0x015c, 0xf7b94472, 0),
+		};
+	}
+
+	private ConfigurationValue createConfigurationValueDescriptor(String valueId, int valueIndex, int valueIdHash, int priority) {
+		return new ConfigurationValue(valueId, valueIndex, valueIdHash, 0, priority, false, false);
+	}
+	
+	public ConfigurationValue[] setAdjustableValuesWater(int value) {
+		return new ConfigurationValue[] {
+				new ConfigurationValue("WarmwasserTSoll", 0x0037, 0x5fc5f901, value, 0, true, false),
+		};
+	}
+	
+
+	@Override
+	public ConfigurationValue[] generateClockConfiguration(long time, TimeZone timezone) {
+		time += timezone.getOffset(time);
+		
+		int value = (int) ((time / 60000) % 1440);
+
+		return new ConfigurationValue[] {
+			new ConfigurationValue("SysTime", 0x0002, 0x17B2C58E, value, 0, true, false),
+		};
+	}
+	
+	public static ConfigurationOptimizerMatcher getMatcher() {
+		return new ConfigurationOptimizerMatcher() {
+			
+			public ConfigurationOptimizer matchOptimizer(int deviceAddress, String version, Customizer customizer, MatcherState state) {
+				if (deviceAddress == 5682) {
+					return new RegumaqX45ConfigurationOptimizer();
+				} else {
+					return null;
+				}
+			}
+			
+		};
+	}
+
+}

--- a/vbus/src/test/java/de/resol/vbus/ConfigurationOptimizerTest.java
+++ b/vbus/src/test/java/de/resol/vbus/ConfigurationOptimizerTest.java
@@ -65,6 +65,13 @@ public class ConfigurationOptimizerTest {
 			oscOldValuesParam = oldValues;
 			return oscValuesResult;
 		}
+
+		public ConfigurationValue[] optimizeSetConfiguration(ConfigurationValue[] newValues, ConfigurationValue[] oldValues) {
+			oscCallCount++;
+			oscNewValuesParam = newValues;
+			oscOldValuesParam = oldValues;
+			return oscValuesResult;
+		}
 		
 		public ConfigurationValue[] generateClockConfiguration(long time, TimeZone timeZone) {
 			gccCallCount++;

--- a/vbus/src/test/java/de/resol/vbus/CustomizerTest.java
+++ b/vbus/src/test/java/de/resol/vbus/CustomizerTest.java
@@ -67,6 +67,14 @@ public class CustomizerTest {
 			return scValuesResult;
 		}
 		
+		@Override
+		protected ConfigurationValue[] setConfigurationInternal(ConfigurationValue[] newValues, ConfigurationValue[] oldValues, boolean optimize) throws IOException {
+			scCallCount++;
+			scNewValuesParam = newValues;
+			scOldValuesParam = oldValues;
+			scOptimizeParam = optimize;
+			return scValuesResult;
+		}		
 	}
 
 	@Test

--- a/vbus/src/test/java/de/resol/vbus/CustomizerTest.java
+++ b/vbus/src/test/java/de/resol/vbus/CustomizerTest.java
@@ -265,5 +265,119 @@ public class CustomizerTest {
 			assertArrayEquals(customizer.scValuesResult, outputValues);
 		}
 	}
+
+	@Test
+	public void testSetConfiguration() throws Exception {
+		// ---- CASE 1: without optimizer ----
+		if (true) {
+			int deviceAddress = 0x4711;
+
+			TestableCustomizer customizer = new TestableCustomizer(deviceAddress, null);
+
+			ConfigurationValue[] newInputValues = new ConfigurationValue [] {
+				new ConfigurationValue(null, 0, 0x0001, -11, 0, false, false),
+				new ConfigurationValue(null, 0, 0x0002, -22, 0, false, false),
+			};
+	
+			ConfigurationValue[] oldInputValues = new ConfigurationValue [] {
+				new ConfigurationValue(null, 0, 0x0001, -10, 0, false, false),
+				new ConfigurationValue(null, 0, 0x0002, -20, 0, false, false),
+			};
+	
+			customizer.scValuesResult = new ConfigurationValue [] {
+				new ConfigurationValue(null, 0, 0x0001, -1, 0, false, false),
+				new ConfigurationValue(null, 0, 0x0002, -2, 0, false, false),
+			};
+			 
+			ConfigurationValue[] outputValues = customizer.setConfiguration(newInputValues, oldInputValues, true);
+			
+			assertEquals(1, customizer.scCallCount);
+			assertArrayEquals(newInputValues, customizer.scNewValuesParam);
+			assertArrayEquals(oldInputValues, customizer.scOldValuesParam);
+			assertEquals(true, customizer.scOptimizeParam);
+			assertArrayEquals(customizer.scValuesResult, outputValues);
+		}
+		
+		// ---- CASE 2: with optimizer, but without oldValues ----
+		if (true) {
+			int deviceAddress = 0x4711;
+
+			final ConfigurationValue[] newInputValues = new ConfigurationValue [] {
+				new ConfigurationValue(null, 0, 0x0001, -11, 0, false, false),
+				new ConfigurationValue(null, 0, 0x0002, -22, 0, false, false),
+			};
+	
+			TestableConfigurationOptimizer optimizer = new TestableConfigurationOptimizer() {
+				
+				@Override
+				public ConfigurationValue[] completeConfiguration(ConfigurationValue[] values) {
+					super.completeConfiguration(values);
+					
+					return values;
+				}
+				
+			};
+
+			TestableCustomizer customizer = new TestableCustomizer(deviceAddress, optimizer);
+
+			customizer.scValuesResult = new ConfigurationValue [] {
+				new ConfigurationValue(null, 0, 0x0001, -1, 0, false, false),
+				new ConfigurationValue(null, 0, 0x0002, -2, 0, false, false),
+			};
+			 
+			ConfigurationValue[] outputValues = customizer.setConfiguration(newInputValues, null, true);
+			
+			assertEquals(1, optimizer.ccCallCount);
+			
+			assertEquals(1, customizer.scCallCount);
+			assertArrayEquals(newInputValues, customizer.scNewValuesParam);
+			assertArrayEquals(null, customizer.scOldValuesParam);
+			assertEquals(true, customizer.scOptimizeParam);
+			assertArrayEquals(customizer.scValuesResult, outputValues);
+		}
+
+		// ---- CASE 3: with optimizer and oldValues ----
+		if (true) {
+			int deviceAddress = 0x4711;
+
+			final ConfigurationValue[] newInputValues = new ConfigurationValue [] {
+				new ConfigurationValue(null, 0, 0x0001, -11, 0, false, false),
+				new ConfigurationValue(null, 0, 0x0002, -22, 0, false, false),
+			};
+	
+			final ConfigurationValue[] oldInputValues = new ConfigurationValue [] {
+				new ConfigurationValue(null, 0, 0x0001, -10, 0, false, false),
+				new ConfigurationValue(null, 0, 0x0002, -20, 0, false, false),
+			};
+	
+			TestableConfigurationOptimizer optimizer = new TestableConfigurationOptimizer() {
+				
+				@Override
+				public ConfigurationValue[] completeConfiguration(ConfigurationValue[] values) {
+					super.completeConfiguration(values);
+					
+					return values;
+				}
+				
+			};
+
+			TestableCustomizer customizer = new TestableCustomizer(deviceAddress, optimizer);
+
+			customizer.scValuesResult = new ConfigurationValue [] {
+				new ConfigurationValue(null, 0, 0x0001, -1, 0, false, false),
+				new ConfigurationValue(null, 0, 0x0002, -2, 0, false, false),
+			};
+			 
+			ConfigurationValue[] outputValues = customizer.setConfiguration(newInputValues, oldInputValues, true);
+			
+			assertEquals(2, optimizer.ccCallCount);
+			
+			assertEquals(1, customizer.scCallCount);
+			assertArrayEquals(newInputValues, customizer.scNewValuesParam);
+			assertArrayEquals(oldInputValues, customizer.scOldValuesParam);
+			assertEquals(true, customizer.scOptimizeParam);
+			assertArrayEquals(customizer.scValuesResult, outputValues);
+		}
+	}
 	
 }


### PR DESCRIPTION
Hello, 

when I tested the `saveConfiguration` method in `/example/customizer/Main` with parameters of the Regumaq X-45 (#25), this did not update the parameters on the controller. I observed that when I use 
`connection.setValueById(address, valueInfo.getValueIndex(), value, false, 500, 500, 3);` (SET)  instead of 
`connection.setValueById(address, valueInfo.getValueIndex(), value, true, 500, 500, 3);` (SAVE),
the configuration was updated successfully.
Accordingly, I introduced the `setConfiguration` method.

I also added a minimal example of the `ConfiguartionOptimizer` class of the Regumaq X-45 with a method to change a parameter.