### PR TITLE
zero channel for DL3

### DIFF
--- a/vbus/src/main/java/de/resol/vbus/TcpConnection.java
+++ b/vbus/src/main/java/de/resol/vbus/TcpConnection.java
@@ -50,7 +50,7 @@ public class TcpConnection extends Connection {
 	
 	private String password;
 	
-	private int channel;
+	private Integer channel;
 	
 	private Thread thread;
 	
@@ -70,7 +70,7 @@ public class TcpConnection extends Connection {
 	 * @param password Password to connect to VBus-over-TCP service.
 	 * @param channel VBus channel to connect to.
 	 */
-	public TcpConnection(int selfAddress, SocketAddress socketAddress, String viaTag, String password, int channel) {
+	public TcpConnection(int selfAddress, SocketAddress socketAddress, String viaTag, String password, Integer channel) {
 		super(selfAddress);
 		this.socketAddress = socketAddress;
 		this.viaTag = viaTag;
@@ -211,7 +211,7 @@ public class TcpConnection extends Connection {
 
 		// FIXME(daniel): insert CHANNELLIST command and callback
 
-		if ((errorMessage == null) && (channel != 0)) {
+		if ((errorMessage == null) && (channel != null)) {
 			out.println("CHANNEL " + channel);
 			out.flush();
 			
@@ -248,7 +248,7 @@ public class TcpConnection extends Connection {
 		Socket previousSocket = this.socket;
 
 		this.socket = socket;
-		this.is = new LiveInputStream(socket.getInputStream(), channel);
+		this.is = new LiveInputStream(socket.getInputStream(), (channel != null)?channel:0);
 		this.os = new LiveOutputStream(socket.getOutputStream());
 		
 		setConnectionState(ConnectionState.CONNECTED);


### PR DESCRIPTION
Datalogger DL3 has internal VBus 0 where its sensors are available in this message:
https://danielwippermann.github.io/resol-vbus/#/vsf/fields/00_0010_0053_10_0100

Zero channel can be selected using CHANNEL command on DL3:
https://danielwippermann.github.io/resol-vbus/#/md/docs/vbus-over-tcp

So, I need to select VBus 0 using TcpConnection, but zero value is ignored.

This pull request tries to solve the problem.