### PR TITLE
Synchronized access to Connection listeners

### DIFF
--- a/vbus/src/main/java/de/resol/vbus/Connection.java
+++ b/vbus/src/main/java/de/resol/vbus/Connection.java
@@ -26,6 +26,7 @@ package de.resol.vbus;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 
 /**
  * The `Connection` class provides the base functionality for all VBus live
@@ -52,7 +53,7 @@ public abstract class Connection {
 	
 	protected int selfAddress;
 	
-	protected ArrayList<ConnectionListener> listeners;
+	protected List<ConnectionListener> listeners;
 	
 	protected ConnectionState connectionState;
 	
@@ -64,7 +65,7 @@ public abstract class Connection {
 	 */
 	protected Connection(int selfAddress) {
 		this.selfAddress = selfAddress;
-		listeners = (ArrayList<ConnectionListener>) Collections.synchronizedList(new ArrayList<ConnectionListener>());
+		listeners = Collections.synchronizedList(new ArrayList<ConnectionListener>());
 		connectionState = ConnectionState.DISCONNECTED;
 	}
 

--- a/vbus/src/main/java/de/resol/vbus/Connection.java
+++ b/vbus/src/main/java/de/resol/vbus/Connection.java
@@ -25,6 +25,7 @@ package de.resol.vbus;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 
 /**
  * The `Connection` class provides the base functionality for all VBus live
@@ -63,7 +64,7 @@ public abstract class Connection {
 	 */
 	protected Connection(int selfAddress) {
 		this.selfAddress = selfAddress;
-		listeners = new ArrayList<ConnectionListener>();
+		listeners = (ArrayList<ConnectionListener>) Collections.synchronizedList(new ArrayList<ConnectionListener>());
 		connectionState = ConnectionState.DISCONNECTED;
 	}
 


### PR DESCRIPTION
Handling connection listeners from multiple threads can cause NullPointerException.

Listeners are cloned in Connection.emitHeaderReceived, but operation listeners.toArray() is not atomic and should be synchronized.

```
Exception in thread "Thread-6" java.lang.NullPointerException: Cannot invoke "de.resol.vbus.ConnectionListener.datagramReceived(de.resol.vbus.Connection, de.resol.vbus.Datagram)" because "listener" is null
         at de.resol.vbus.Connection.emitHeaderReceived(Connection.java:166)
```